### PR TITLE
Team specific timeouts

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -730,6 +730,15 @@ type DefaultDecorationConfigEntry struct {
 	// ProwJob is configured to run on. Recall that ProwJobs default to running on
 	// the "default" build cluster if they omit the "cluster" field in config.
 	Cluster string `json:"cluster,omitempty"`
+	// PodPendingTimeout is after how long the controller will perform a garbage
+	// collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+	PodPendingTimeout *metav1.Duration `json:"pod_pending_timeout,omitempty"`
+	// PodRunningTimeout is after how long the controller will abort a prowjob pod
+	// stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+	PodRunningTimeout *metav1.Duration `json:"pod_running_timeout,omitempty"`
+	// PodUnscheduledTimeout is after how long the controller will abort a prowjob
+	// stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+	PodUnscheduledTimeout *metav1.Duration `json:"pod_unscheduled_timeout,omitempty"`
 
 	// Config is the DecorationConfig to apply if the filter fields all match the
 	// ProwJob. Note that when multiple entries match a ProwJob they are all used

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -5167,6 +5167,42 @@ default_decoration_config_entries:
 			},
 		},
 		{
+			name: "OrgRepo,Cluster timeouts",
+			raw: `
+default_decoration_config_entries:
+  - repo: "org"
+    pod_running_timeout: 3h
+  - repo: "org/repo"
+    pod_running_timeout: 2h
+  - repo: "org/foo"
+    pod_running_timeout: 1h
+  - cluster: "trusted"
+    pod_running_timeout: 30m
+`,
+			expected: []*DefaultDecorationConfigEntry{
+				{
+					OrgRepo:           "org",
+					Cluster:           "",
+					PodRunningTimeout: &metav1.Duration{Duration: 3 * time.Hour},
+				},
+				{
+					OrgRepo:           "org/repo",
+					Cluster:           "",
+					PodRunningTimeout: &metav1.Duration{Duration: 2 * time.Hour},
+				},
+				{
+					OrgRepo:           "org/foo",
+					Cluster:           "",
+					PodRunningTimeout: &metav1.Duration{Duration: 1 * time.Hour},
+				},
+				{
+					OrgRepo:           "",
+					Cluster:           "trusted",
+					PodRunningTimeout: &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			},
+		},
+		{
 			name: "both formats, expect error",
 			raw: `
 default_decoration_configs:

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -725,6 +725,15 @@ plank:
           # job is a periodic without extra_refs, the empty string will be used.
           # If this field is omitted all jobs will match.
           repo: ' '
+          # PodPendingTimeout is after how long the controller will perform a garbage
+          # collection on pending pods. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+          pod_pending_timeout: 0s
+          # PodRunningTimeout is after how long the controller will abort a prowjob pod
+          # stuck in running state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+          pod_running_timeout: 0s
+          # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+          # stuck in an unscheduled state. Specific for OrgRepo or Cluster. If not set, it has a fallback inside plank field.
+          pod_unscheduled_timeout: 0s
     # DefaultDecorationConfigsMap is a mapping from 'org', 'org/repo', or the
     # literal string '*', to the default decoration config to use for that key.
     # The '*' key matches all jobs. (Periodics use extra_refs[0] for matching

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -164,6 +164,14 @@ type shardedLock struct {
 	locks   map[string]*semaphore.Weighted
 }
 
+type timeout string
+
+const (
+	PodRunningTimeout     timeout = "PodRunningTimeout"
+	PodPendingTimeout     timeout = "PodPendingTimeout"
+	PodUnscheduledTimeout timeout = "PodUnscheduledTimeout"
+)
+
 func (s *shardedLock) getLock(key string) *semaphore.Weighted {
 	s.mapLock.Lock()
 	defer s.mapLock.Unlock()


### PR DESCRIPTION
Add Org/Repo/Cluster specific timeouts in `DefaultDecorationConfigEntries` for overriding values set in `plank:` stanza

- [x]  PodRunningTimeout
- [ ]  PodPendingTimeout
- [ ]  PodUnscheduledTimeout